### PR TITLE
fix subgraph type

### DIFF
--- a/src/interfaces/subgraphTypes.ts
+++ b/src/interfaces/subgraphTypes.ts
@@ -2,23 +2,23 @@
 ////////////////////    ENUMS     //////////////////////////////
 ////////////////////////////////////////////////////////////////
 export enum OrderType {
-  OPEN_NEW_POSITION,
-  CLOSE_POSITION,
-  INCREASE_POSITION,
-  DECREASE_POSITION,
-  CANCEL_ORDER,
+  OPEN_NEW_POSITION = 'OPEN_NEW_POSITION',
+  CLOSE_POSITION = 'CLOSE_POSITION',
+  INCREASE_POSITION = 'INCREASE_POSITION',
+  DECREASE_POSITION = 'DECREASE_POSITION',
+  CANCEL_ORDER = 'CANCEL_ORDER',
 }
 
 export enum OrderStatus {
-  PENDING,
-  CANCELLED,
-  SETTLED,
+  PENDING = 'PENDING',
+  CANCELLED = 'CANCELLED',
+  SETTLED = 'SETTLED',
 }
 
 export enum PositionStatus {
-  OPEN,
-  CLOSED,
-  LIQUIDATED,
+  OPEN = 'OPEN',
+  CLOSED = 'CLOSED',
+  LIQUIDATED = 'LIQUIDATED',
 }
 
 ////////////////////////////////////////////////////////////////
@@ -206,7 +206,7 @@ export interface Order {
   // " Account/Address of the order "
   user?: Account;
 
-  // " 0 => OPEN, 1 => CLOSE, 2 => INCREASE, 3 => DECREASE "
+  // "OPEN, CLOSE, INCREASE, DECREASE "
   orderType?: OrderType;
 
   // " True if LONG order "


### PR DESCRIPTION
- [x] fix order and positions status
currently we have a bad typing on the sdk this pr fix the enum types related to the positions and order statuses

![image](https://github.com/Parifi/parifi-sdk/assets/56121549/c6b6fad7-39fe-4de8-9fe1-a4390cb7390f)
![image](https://github.com/Parifi/parifi-sdk/assets/56121549/48728d7c-dc03-4969-b9f6-0d0c9dcdcea5)
